### PR TITLE
Connect Authentication API (Login, Registration) with Frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ jspm_packages/
 
 # dotenv environment variable files
 .env
+.env.development
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test

--- a/backend/server/package-lock.json
+++ b/backend/server/package-lock.json
@@ -12,6 +12,7 @@
         "@types/bcryptjs": "^2.4.4",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.6",
+        "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-jwt": "^8.4.1",
@@ -1764,6 +1765,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -4294,6 +4307,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/server/package.json
+++ b/backend/server/package.json
@@ -22,6 +22,7 @@
     "@types/bcryptjs": "^2.4.4",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-jwt": "^8.4.1",
@@ -33,9 +34,9 @@
     "tsx": "^3.14.0"
   },
   "devDependencies": {
-    "@types/cookie-parser": "^1.4.5",
     "@types/bcryptjs": "^2.4.5",
     "@types/chai": "^4.3.6",
+    "@types/cookie-parser": "^1.4.5",
     "@types/express": "^4.17.18",
     "@types/mocha": "^10.0.2",
     "@types/node": "^20.8.2",

--- a/backend/server/package.json
+++ b/backend/server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prestart": "npm install",
     "start": "tsx src/index.ts",
-    "dev": "tsx watch src/index.ts",
+    "dev": "DOTENV_CONFIG_PATH=.env.development NODE_ENV=development tsx watch src/index.ts",
     "test": "ts-mocha test/*.ts",
     "lint": "eslint './src/**/*.ts' --cache --cache-strategy content ",
     "lint:fix": "eslint --fix './src/**/*.ts'"

--- a/backend/server/src/index.ts
+++ b/backend/server/src/index.ts
@@ -4,6 +4,7 @@ import express, {
   type Application,
   type NextFunction
 } from "express";
+import cors from 'cors';
 import connectDB from "./utility/db.js";
 import cookieParser from "cookie-parser";
 import swaggerUi from "swagger-ui-express";
@@ -23,6 +24,9 @@ const port = process.env.PORT ?? 8080;
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
+app.use(cors({
+  origin: 'http://localhost:3000'
+}));
 
 /**
  * Serves swagger

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 NODE_ENV=dev
+REACT_APP_API_URL=<URL here>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="fi">
 
 <head lang="en">
-  <title>Kendo app woo!</title>
+  <title>Kendo Tournament Management</title>
 
 </html>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.6.0",
         "dotenv": "^16.3.1",
         "eslint-webpack-plugin": "^4.0.1",
         "react": "^18.2.0",
@@ -1828,9 +1829,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -1842,6 +1841,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2250,8 +2259,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2759,8 +2766,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4094,7 +4099,6 @@
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
       "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4123,8 +4127,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6825,6 +6827,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' mocha",
     "start": "webpack serve --port 3000",
-    "dev": "DOTENV_CONFIG_PATH=.env.development NODE_ENV=development webpack serve --port 3000",
+    "dev": "webpack serve --mode development",
     "build": "NODE_ENV=production webpack",
     "lint": "eslint './src/**/*.{ts,tsx}' --cache --cache-strategy content ",
     "lint:fix": "eslint --fix './src/**/*.{ts,tsx}'"
@@ -55,6 +55,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
+    "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "eslint-webpack-plugin": "^4.0.1",
     "react": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' mocha",
     "start": "webpack serve --port 3000",
+    "dev": "DOTENV_CONFIG_PATH=.env.development NODE_ENV=development webpack serve --port 3000",
     "build": "NODE_ENV=production webpack",
     "lint": "eslint './src/**/*.{ts,tsx}' --cache --cache-strategy content ",
     "lint:fix": "eslint --fix './src/**/*.{ts,tsx}'"

--- a/frontend/src/components/modules/Login/Login.tsx
+++ b/frontend/src/components/modules/Login/Login.tsx
@@ -19,16 +19,12 @@ const LoginForm: React.FC = () => {
   const { login } = useAuth();
   const location = useLocation() as unknown as LocationProps;
   const from = location.state?.from?.pathname ?? "/";
+  const loginAPI = "http://localhost:8080/api/user/login";
 
   const [formData, setFormData] = useState<FormData>({
     login: "",
     password: ""
   });
-
-  const onHandleSubmit = async (): Promise<void> => {
-    await login();
-    navigate(from, { replace: true });
-  };
 
   const handleInputChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -42,6 +38,39 @@ const LoginForm: React.FC = () => {
       ...prevData,
       [fieldName]: value
     }));
+  };
+
+  const onHandleSubmit = async (
+    event: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
+    event.preventDefault(); // Prevent the default form submit behavior
+    try {
+      const response = await fetch(loginAPI, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          email: formData.login,
+          password: formData.password
+        })
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        console.log(data);
+        // Store the token, and update auth state
+        await login();
+        navigate(from, { replace: true });
+      } else {
+        // TODO: display a message to the user
+        const errorData = await response.json();
+        console.error("Login failed:", errorData);
+      }
+    } catch (error) {
+      // TODO: display a message to the user
+      console.error("There was a problem with the login request: ", error);
+    }
   };
 
   return (

--- a/frontend/src/components/modules/Registeration/Registration.tsx
+++ b/frontend/src/components/modules/Registeration/Registration.tsx
@@ -1,7 +1,10 @@
-import React, { type SyntheticEvent, useState } from "react";
+import React, { useState } from "react";
 import "./registration.css";
+import { useNavigate } from "react-router-dom";
 
 const RegisterForm: React.FC = () => {
+  const navigate = useNavigate();
+
   const [formData, setFormData] = useState({
     firstname: "",
     lastname: "",
@@ -17,6 +20,7 @@ const RegisterForm: React.FC = () => {
     guardianEmail: "",
     conditions: false
   });
+  const RegistrationAPI = "http://localhost:8080/api/user/register";
 
   const handleInputChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -32,15 +36,49 @@ const RegisterForm: React.FC = () => {
     }));
   };
 
+  const onHandleSubmit = async (
+    event: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
+    event.preventDefault(); // Prevent the default form submit behavior
+    // mapping state variables to the expected payload keys
+    const payload = {
+      email: formData.email,
+      password: formData.password,
+      firstName: formData.firstname,
+      lastName: formData.lastname,
+      phoneNumber: formData.tel,
+      clubName: formData.club,
+      danRank: formData.rank,
+      underage: formData.underage,
+      guardiansEmail: formData.guardianEmail
+    };
+    // Perform the API call
+    try {
+      const response = await fetch(RegistrationAPI, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+      if (response.ok) {
+        const data = await response.json();
+        // TODO: display success message for 2 second maybe
+        console.log(data);
+        navigate("/login");
+      } else {
+        // TODO: display a message to the user
+        const errorData = await response.json();
+        console.error("Login failed:", errorData);
+      }
+    } catch (error) {
+      // TODO: display a message to the user
+      console.error("There was an error registering the user", error);
+    }
+  };
+
   return (
-    <form
-      id="registerForm"
-      className="form"
-      onSubmit={(event: SyntheticEvent) => {
-        event.preventDefault();
-        /** here how user is actually added somewhere */
-      }}
-    >
+    <form id="registerForm" className="form" onSubmit={onHandleSubmit}>
       <h1 className="header">Create a KendoApp account</h1>
       <p className="subtext">
         Already have an account? <a href="url">Log in</a>{" "}


### PR DESCRIPTION
## Features
1. Added Login, Registration API request to backend using fetch. 
2. Added cors in the backend. 
3. Added `dev` in package.json for both front-end and back-end. They use different '.env' files, that's the only difference.

These commits tie the front end with the back end. Front-end API functionalities need to be checked. I couldn't figure out how to use '.env' support on Webpack. Base API URLs can be put in the '.env' file. 

## TODO @vilbedawg 
1. Add Error handling message for `login` and `registration` API calls. 
2. API calls can be turned into a utility function. A suggestion.
3. Add `.env` support on the front end.