### PR TITLE
Fix a false error message

### DIFF
--- a/frontend/src/components/modules/Login/Login.tsx
+++ b/frontend/src/components/modules/Login/Login.tsx
@@ -108,7 +108,9 @@ const LoginForm: React.FC = () => {
                 Sign In!
               </Typography>
 
-              <ShowError message={errorMessage.message}></ShowError>
+              {errorMessage.message !== "" && (
+                <ShowError message={errorMessage.message}></ShowError>
+              )}
               <TextField
                 label="Username/Email"
                 type="text"


### PR DESCRIPTION
localhost:3000/login has been printing a false error message.
The print is done in Error.tsx at line 14. This was caused by always rendering the error component.