### PR TITLE
Improvement/event-scoped-authorization

### DIFF
--- a/backend/server/src/controllers/matchController.ts
+++ b/backend/server/src/controllers/matchController.ts
@@ -37,34 +37,34 @@ export class MatchController extends Controller {
   /*
    * Retrieve details of a specific Kendo match.
    */
-  @Get("{id}")
+  @Get("{matchId}")
   @Tags("Match")
-  public async getMatch(@Path() id: ObjectIdString): Promise<Match> {
+  public async getMatch(@Path() matchId: ObjectIdString): Promise<Match> {
     this.setStatus(200);
-    return await this.service.getMatchById(id);
+    return await this.service.getMatchById(matchId);
   }
 
   /*
    * Delete a Kendo match.
    */
   @Security("jwt", ["official"])
-  @Delete("{id}")
+  @Delete("{matchId}")
   @Tags("Match")
-  public async deleteMatch(@Path() id: ObjectIdString): Promise<void> {
+  public async deleteMatch(@Path() matchId: ObjectIdString): Promise<void> {
     this.setStatus(204);
-    await this.service.deleteMatchById(id);
+    await this.service.deleteMatchById(matchId);
   }
 
   /*
    * Start the timer for the specified Kendo match.
    */
   @Security("jwt", ["official"])
-  @Patch("{id}/start-timer")
+  @Patch("{matchId}/start-timer")
   @Tags("Match")
-  public async startTimer(@Path() id: ObjectIdString): Promise<void> {
+  public async startTimer(@Path() matchId: ObjectIdString): Promise<void> {
     this.setStatus(204);
 
-    const match = await this.service.startTimer(id);
+    const match = await this.service.startTimer(matchId);
 
     io.to(match.id).emit("start-timer", match);
   }
@@ -73,12 +73,12 @@ export class MatchController extends Controller {
    * Stop the timer for the specified Kendo match.
    */
   @Security("jwt", ["official"])
-  @Patch("{id}/stop-timer")
+  @Patch("{matchId}/stop-timer")
   @Tags("Match")
-  public async stopTimer(@Path() id: ObjectIdString): Promise<void> {
+  public async stopTimer(@Path() matchId: ObjectIdString): Promise<void> {
     this.setStatus(204);
 
-    const match = await this.service.stopTimer(id);
+    const match = await this.service.stopTimer(matchId);
 
     io.to(match.id).emit("stop-timer", match);
   }
@@ -87,16 +87,16 @@ export class MatchController extends Controller {
    * Add a point to the specified Kendo match.
    */
   @Security("jwt", ["official"])
-  @Patch("{id}/points")
+  @Patch("{matchId}/points")
   @Tags("Match")
   public async addPoint(
-    @Path() id: ObjectIdString,
+    @Path() matchId: ObjectIdString,
     @Body() updateMatchRequest: AddPointRequest
   ): Promise<void> {
     this.setStatus(204);
 
     const match = await this.service.addPointToMatchById(
-      id,
+      matchId,
       updateMatchRequest
     );
 

--- a/backend/server/src/controllers/matchController.ts
+++ b/backend/server/src/controllers/matchController.ts
@@ -66,7 +66,7 @@ export class MatchController extends Controller {
 
     const match = await this.service.startTimer(matchId);
 
-    io.to(match.id).emit("start-timer", match);
+    io.to(matchId).emit("start-timer", match);
   }
 
   /*
@@ -80,7 +80,7 @@ export class MatchController extends Controller {
 
     const match = await this.service.stopTimer(matchId);
 
-    io.to(match.id).emit("stop-timer", match);
+    io.to(matchId).emit("stop-timer", match);
   }
 
   /*
@@ -100,7 +100,7 @@ export class MatchController extends Controller {
       updateMatchRequest
     );
 
-    io.to(match.id).emit("add-point", match);
+    io.to(matchId).emit("add-point", match);
   }
 
   private get service(): MatchService {

--- a/backend/server/src/models/matchModel.ts
+++ b/backend/server/src/models/matchModel.ts
@@ -25,6 +25,8 @@ export interface Match {
   players: MatchPlayer[];
   winner?: string;
   comment?: string;
+  admin: Types.ObjectId;
+  officials?: Types.ObjectId[];
 }
 
 const pointSchema = new Schema<MatchPoint>(
@@ -65,7 +67,15 @@ const matchSchema = new Schema<Match>({
     maxlength: 2,
     minlength: 2
   },
-  comment: { type: String, required: false }
+  comment: { type: String, required: false },
+  admin: {
+    type: Schema.Types.ObjectId,
+    required: true
+  },
+  officials: {
+    type: [Schema.Types.ObjectId],
+    default: []
+  }
 });
 
 matchSchema.set("toObject", {

--- a/backend/server/src/models/requestModel.ts
+++ b/backend/server/src/models/requestModel.ts
@@ -9,13 +9,6 @@ import type { MatchType, PlayerColor, PointType } from "./matchModel.js";
  */
 export type ObjectIdString = string;
 
-export enum UserRole {
-  None,
-  Player,
-  Official,
-  Admin
-}
-
 export interface RegisterRequest {
   /**
    * @example "john.doe@gmail.com"
@@ -88,6 +81,8 @@ export interface CreateMatchRequest {
    * @maxItems 2 Two players are required
    */
   players: MatchPlayerPayload[];
+  admin: ObjectIdString;
+  officials: ObjectIdString[];
   matchType: MatchType;
   comment?: string;
 }

--- a/backend/server/src/models/userModel.ts
+++ b/backend/server/src/models/userModel.ts
@@ -1,8 +1,8 @@
-import mongoose, { Schema } from "mongoose";
+import mongoose, { Schema, type Types } from "mongoose";
 import bcrypt from "bcryptjs";
 
 export interface User {
-  id: string;
+  id: Types.ObjectId;
   email: string;
   password: string;
   userName?: string;
@@ -23,7 +23,7 @@ interface UserMethods {
   checkPassword: (password: string) => Promise<boolean>;
 }
 
-type UserModel = mongoose.Model<User, Record<string, unknown>, UserMethods>;
+type UserModelType = mongoose.Model<User, Record<string, unknown>, UserMethods>;
 
 const schema = new Schema<User, UserMethods>(
   {
@@ -54,6 +54,7 @@ schema.set("toObject", {
     if (doc.isSelected("password")) {
       delete ret.password;
     }
+    ret.id = ret._id;
     delete ret._id;
   }
 });
@@ -79,4 +80,6 @@ schema.methods.checkPassword = async function (candidatePassword: string) {
   return await bcrypt.compare(candidatePassword, this.password);
 };
 
-export default mongoose.model<User, UserModel>("User", schema);
+const UserModel = mongoose.model<User, UserModelType>("User", schema);
+
+export default UserModel;

--- a/backend/server/src/services/matchService.ts
+++ b/backend/server/src/services/matchService.ts
@@ -127,7 +127,7 @@ export class MatchService {
     id: string,
     requestBody: AddPointRequest
   ): Promise<Match> {
-    const match = await MatchModel.findById(id);
+    const match = await MatchModel.findById(id).exec();
 
     if (match === null) {
       throw new NotFoundError({

--- a/backend/server/src/services/matchService.ts
+++ b/backend/server/src/services/matchService.ts
@@ -20,7 +20,9 @@ export class MatchService {
     const newMatch = await MatchModel.create({
       type: requestBody.matchType,
       players: requestBody.players,
-      comment: requestBody.comment
+      admin: requestBody.admin,
+      comment: requestBody.comment,
+      officials: requestBody.officials
     });
 
     return await newMatch.toObject();

--- a/backend/server/src/utility/jwtHelper.ts
+++ b/backend/server/src/utility/jwtHelper.ts
@@ -1,12 +1,11 @@
 import jwt from "jsonwebtoken";
 import config from "./config";
 import UnauthorizedError from "../errors/UnauthorizedError";
-import { type UserRole } from "../models/requestModel";
 
 export interface TokenPayload {
   id: string;
-  email: string;
-  role: UserRole;
+  adminTournaments: string[];
+  officialTournaments: string[];
 }
 
 export const generateAccessToken = (
@@ -36,7 +35,7 @@ export async function verifyRefreshToken(token: string): Promise<TokenPayload> {
         );
       } else {
         // Cast the decoded token to JwtPayload and then resolve it
-        resolve(decoded as TokenPayload);
+        resolve(decoded as unknown as TokenPayload);
       }
     });
   });


### PR DESCRIPTION
Due to how roles are handled in the events, we cannot have roles tied to the user. These changes implement a solution where the role of a user is stored in the match.

One note for the future; Once we have tournament API ready, we could change the paths for the matches, 
I.e., `\{tournamentId}\matches\{matchId}`. We could then store all the role-related stuff in the tournament document instead and keep the match document even simpler. However, I'm not sure if the roles can change within a tournament, which would require the roles to be scoped only to the matches within the tournament, at least for officials.

In addition, this type of authorization has one caveat; If a new match is created and the user is assigned a new role in that event, then the user's token should be retrieved again in order to update the roles. One fix for this would be to make the access tokens even more short-lived, which would require the user to fetch new access tokens frequently. However, this is still not an instant update, but I think sufficient for the MVP.  