### PR TITLE
Hotfix/fix backend build

### DIFF
--- a/backend/server/src/controllers/tournamentController.ts
+++ b/backend/server/src/controllers/tournamentController.ts
@@ -24,11 +24,13 @@ import type * as express from "express";
 
 @Route("tournaments")
 export class TournamentController extends Controller {
-  @Get("{id}")
+  @Get("{tournamentId}")
   @Tags("Tournaments")
-  public async getTournament(@Path() id: ObjectIdString): Promise<Tournament> {
+  public async getTournament(
+    @Path() tournamentId: ObjectIdString
+  ): Promise<Tournament> {
     this.setStatus(200);
-    return await this.service.getTournamentById(id);
+    return await this.service.getTournamentById(tournamentId);
   }
 
   @Get()
@@ -41,7 +43,7 @@ export class TournamentController extends Controller {
   }
 
   @Security("jwt")
-  @Post("create")
+  @Post()
   @Tags("Tournaments")
   public async createTournament(
     @Request() request: express.Request & { user: JwtPayload },
@@ -69,7 +71,7 @@ export class TournamentController extends Controller {
   }
 
   @Security("jwt")
-  @Put("{tournamentId}/manualSchedule")
+  @Put("{tournamentId}/manual-schedule")
   @Tags("Tournaments")
   public async manualSchedule(
     @Path() tournamentId: ObjectIdString,
@@ -79,7 +81,7 @@ export class TournamentController extends Controller {
       tournamentId,
       requestBody
     );
-    this.setStatus(201); // Created status
+    this.setStatus(201);
     return result;
   }
 

--- a/backend/server/src/models/tournamentModel.ts
+++ b/backend/server/src/models/tournamentModel.ts
@@ -8,15 +8,14 @@ export enum TournamentType {
   PreliminiaryPlayoff = "Preliminary Playoff"
 }
 
-export interface UnsavedMatch
-  extends Pick<
-    Match,
-    | "players"
-    | "type"
-    | "elapsedTime"
-    | "timerStartedTimestamp"
-    | "tournamentRound"
-  > {}
+export type UnsavedMatch = Pick<
+  Match,
+  | "players"
+  | "type"
+  | "elapsedTime"
+  | "timerStartedTimestamp"
+  | "tournamentRound"
+>;
 
 export interface Tournament {
   id: Types.ObjectId;

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -81,7 +81,7 @@ const tournaments = {
     });
   },
   createNew: async (body: CreateTournamentRequest) => {
-    return await request.post<Tournament>(`${TOURNAMENTS_API}/create`, body);
+    return await request.post<Tournament>(`${TOURNAMENTS_API}`, body);
   },
   signup: async (tournamentId: string, body: SignupForTournamentRequest) => {
     return await request.put(


### PR DESCRIPTION
For some reason, the build script got stuck over the `UnsavedMatch` being an extended interface. Changing it to type fixed the issue. 

I have no idea why this happened since running the build didn't give any errors; it just got stuck in a loop.

I also went ahead and changed few of the tournament routes to match our other endpoints casing