### PR TITLE
Fix/profile info edit fixes

### DIFF
--- a/backend/server/src/controllers/matchController.ts
+++ b/backend/server/src/controllers/matchController.ts
@@ -24,9 +24,9 @@ export class MatchController extends Controller {
   /*
    * Create a new Kendo match.
    */
-  @Security("jwt")
   @Post()
   @Tags("Match")
+  @Security("jwt")
   public async createMatch(
     @Body() requestBody: CreateMatchRequest
   ): Promise<Match> {
@@ -47,9 +47,9 @@ export class MatchController extends Controller {
   /*
    * Delete a Kendo match.
    */
-  @Security("jwt")
   @Delete("{matchId}")
   @Tags("Match")
+  @Security("jwt")
   public async deleteMatch(@Path() matchId: ObjectIdString): Promise<void> {
     this.setStatus(204);
     await this.service.deleteMatchById(matchId);
@@ -58,9 +58,9 @@ export class MatchController extends Controller {
   /*
    * Start the timer for the specified Kendo match.
    */
-  @Security("jwt")
   @Patch("{matchId}/start-timer")
   @Tags("Match")
+  @Security("jwt")
   public async startTimer(@Path() matchId: ObjectIdString): Promise<void> {
     this.setStatus(204);
 
@@ -72,9 +72,9 @@ export class MatchController extends Controller {
   /*
    * Stop the timer for the specified Kendo match.
    */
-  @Security("jwt")
   @Patch("{matchId}/stop-timer")
   @Tags("Match")
+  @Security("jwt")
   public async stopTimer(@Path() matchId: ObjectIdString): Promise<void> {
     this.setStatus(204);
 
@@ -86,9 +86,9 @@ export class MatchController extends Controller {
   /*
    * Add a point to the specified Kendo match.
    */
-  @Security("jwt")
   @Patch("{matchId}/points")
   @Tags("Match")
+  @Security("jwt")
   public async addPoint(
     @Path() matchId: ObjectIdString,
     @Body() updateMatchRequest: AddPointRequest

--- a/backend/server/src/controllers/tournamentController.ts
+++ b/backend/server/src/controllers/tournamentController.ts
@@ -42,9 +42,9 @@ export class TournamentController extends Controller {
     return await this.service.getAllTournaments(limit);
   }
 
-  @Security("jwt")
   @Post()
   @Tags("Tournaments")
+  @Security("jwt")
   public async createTournament(
     @Request() request: express.Request & { user: JwtPayload },
     @Body() tournamentData: CreateTournamentRequest
@@ -56,9 +56,9 @@ export class TournamentController extends Controller {
     return await this.service.createTournament(tournamentData, creator);
   }
 
-  @Security("jwt")
   @Put("{tournamentId}/sign-up")
   @Tags("Tournaments")
+  @Security("jwt")
   public async signUpForTournament(
     @Path() tournamentId: ObjectIdString,
     @Body() requestBody: SignupForTournamentRequest
@@ -70,9 +70,9 @@ export class TournamentController extends Controller {
     );
   }
 
-  @Security("jwt")
   @Put("{tournamentId}/manual-schedule")
   @Tags("Tournaments")
+  @Security("jwt")
   public async manualSchedule(
     @Path() tournamentId: ObjectIdString,
     @Body() requestBody: UnsavedMatch

--- a/backend/server/src/controllers/userController.ts
+++ b/backend/server/src/controllers/userController.ts
@@ -20,8 +20,8 @@ import {
 
 @Route("user")
 export class UserController extends Controller {
-  @Security("jwt")
   @Get("{id}")
+  @Security("jwt")
   @Tags("User")
   public async getUser(@Path() id: ObjectIdString): Promise<User> {
     this.setStatus(200);
@@ -40,6 +40,7 @@ export class UserController extends Controller {
   }
 
   @Put("{id}")
+  @Security("jwt")
   @Tags("User")
   public async editUser(
     @Path() id: ObjectIdString,
@@ -51,6 +52,7 @@ export class UserController extends Controller {
   }
 
   @Delete("{id}")
+  @Security("jwt")
   @Tags("User")
   public async deleteUser(@Path() id: ObjectIdString): Promise<void> {
     this.setStatus(204);

--- a/backend/server/tsoa.json
+++ b/backend/server/tsoa.json
@@ -1,6 +1,6 @@
 {
   "entryFile": "src/index.ts",
-  "noImplicitAdditionalProperties": "throw-on-extras",
+  "noImplicitAdditionalProperties": "silently-remove-extras",
   "controllerPathGlobs": [
     "src/controllers/**/*Controller.ts"
   ],

--- a/frontend/src/components/modules/Profile/EditInfoButtonRow.tsx
+++ b/frontend/src/components/modules/Profile/EditInfoButtonRow.tsx
@@ -54,7 +54,7 @@ const EditButtonRow: React.FC<EditButtonRowProps> = ({
         type="submit"
         variant="contained"
         color="primary"
-        disabled={!editingEnabled || !formContext.formState.isValid}
+        disabled={!editingEnabled || !formContext.formState.isDirty}
         sx={{ mt: 3, mb: 2 }}
       >
         Save info

--- a/frontend/src/components/modules/Profile/Profile.tsx
+++ b/frontend/src/components/modules/Profile/Profile.tsx
@@ -40,7 +40,7 @@ const defaultValues: EditUserRequest = {
 const Profile: React.FC = () => {
   const navigate = useNavigate();
   const showToast = useToast();
-  const { userId, logout } = useAuth();
+  const { userId } = useAuth();
 
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
@@ -94,14 +94,10 @@ const Profile: React.FC = () => {
   const onSubmit = async (data: EditUserRequest): Promise<void> => {
     try {
       await api.user.update(userId, data);
-      await logout();
       showToast(
-        "Your information has been updated successfully! Please log in again to see the changes.",
+        "Your information has been updated successfully! Please refresh the page to see the changes.",
         "success"
       );
-      navigate(routePaths.login, {
-        replace: true
-      });
     } catch (error) {
       showToast(error, "error");
     }

--- a/frontend/src/components/modules/Profile/Profile.tsx
+++ b/frontend/src/components/modules/Profile/Profile.tsx
@@ -232,15 +232,17 @@ const Profile: React.FC = () => {
               formContext.setValue("underage", e.target.checked);
             }}
           />
-          <TextFieldElement
-            required
-            name="guardiansEmail"
-            label="Guardian's Email Address"
-            type="email"
-            fullWidth
-            margin="normal"
-            disabled={!editingEnabled || !(underage as boolean)}
-          />
+          {(underage as boolean) && (
+            <TextFieldElement
+              required
+              name="guardiansEmail"
+              label="Guardian's Email Address"
+              type="email"
+              fullWidth
+              margin="normal"
+              disabled={!editingEnabled}
+            />
+          )}
           <EditButtonRow
             editingEnabled={editingEnabled}
             setEditingEnabled={setEditingEnabled}


### PR DESCRIPTION
Some minor fixes from the previous PRs

Also, one major change here is the tsoa config change, which ultimately allows extra properties in the API request bodies, which are then silently removed in the API. This is mainly to mimic the behavior of C# serializers and other popular JSON serializer. In other words, it allows us to effectively reuse existing types for sending requests to the server without worrying about excess properties being sent along.

I also went ahead with @melinaruu's suggestion about not forcing the users to logout after making changes to their profile after testing out how it played out. This change is a lot nicer UX.